### PR TITLE
Document `git fetch --tags` for CI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Add this to your sbt build plugins, in either `project/plugins.sbt` or `project/
 
 Then make sure to **NOT set the version setting**, otherwise you will override `sbt-dynver`.
 
+In CI, you may need to run `git fetch --tags` if the repo is cloned with `--no-tags`.
+
 Other than that, as `sbt-dynver` is an AutoPlugin that is all that is required.
 
 ## Detail


### PR DESCRIPTION
Thank you for a great project! I bumped into this while setting up sbt-dynver in the scalafmt repo, since drone CI clones the repo with `--no-tags` by default.