### PR TITLE
Add support for detecting previous stable version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ Inspired by:
 * The way that Mercurial [versions itself](https://selenic.com/hg/file/3.9.1/setup.py#l179)
 * The [GitVersioning][] AutoPlugin in [sbt-git][].
 
+Features:
+* Dynamically set your version by looking at the closest tag to the current commit
+* Detect the previous version
+    * Useful for automatic [binary compatibility checks](https://github.com/lightbend/migration-manager) across library versions
+
 [sbt-git]: https://github.com/sbt/sbt-git
 [GitVersioning]: https://github.com/sbt/sbt-git/blob/v0.8.5/src/main/scala/com/typesafe/sbt/SbtGit.scala#L266-L270
 
@@ -42,6 +47,22 @@ Other than that, as `sbt-dynver` is an AutoPlugin that is all that is required.
 | when there are no tags, on commit 1234abcd with local changes        | 1234abcd+20140707-1030         | true       | false           |
 | when there are no commits, or the project isn't a git repo           | HEAD+20140707-1030             | true       | false           |
 ```
+
+#### Previous Version Detection
+Given the following git history, here's what `previousStableVersion` returns when at each commit:
+```
+*   (tagged: v1.1.0)       --> Some("1.0.0")
+*   (untagged)             --> Some("1.0.0")
+| * (tagged: v2.1.0)       --> Some("2.0.0")
+| * (tagged: v2.0.0)       --> Some("1.0.0")
+|/  
+*   (tagged: v1.0.0)       --> None
+*   (untagged)             --> None
+```
+Previous version is detected by looking at the closest tag of the parent commit of HEAD.
+
+If the current commit has multiple parents, the first parent will be used. In git, the first parent
+comes from the branch you merged into (e.g. `master` in `git checkout master && git merge my-feature-branch`)
 
 ## Tag Requirements
 

--- a/src/test/scala/sbtdynver/RepoStates.scala
+++ b/src/test/scala/sbtdynver/RepoStates.scala
@@ -1,21 +1,26 @@
 package sbtdynver
 
-import java.nio.file._, StandardOpenOption._
+import java.nio.file._
+import StandardOpenOption._
 import java.util._
 
-import scala.collection.JavaConverters._
+import org.eclipse.jgit.api.MergeCommand.FastForwardMode
 
+import scala.collection.JavaConverters._
 import org.eclipse.jgit.api._
+import org.eclipse.jgit.merge.MergeStrategy
 
 object RepoStates {
-  def notAGitRepo()               = State()
-  def noCommits()                 = notAGitRepo().init()
-  def onCommit()                  = noCommits().commit()
-  def onCommitDirty()             = onCommit().dirty()
-  def onTag(n: String = "v1.0.0") = onCommit().tag(n)
-  def onTagDirty()                = onTag().dirty()
-  def onTagAndCommit()            = onTag().commit()
-  def onTagAndCommitDirty()       = onTagAndCommit().dirty()
+  def notAGitRepo()                     = State()
+  def noCommits()                       = notAGitRepo().init()
+  def onCommit()                        = noCommits().commit()
+  def onCommitDirty()                   = onCommit().dirty()
+  def onTag(n: String = "v1.0.0")       = onCommit().tag(n)
+  def onTagDirty()                      = onTag().dirty()
+  def onTagAndCommit()                  = onTag().commit()
+  def onTagAndCommitDirty()             = onTagAndCommit().dirty()
+  def onTagAndSecondCommit()            = onTagAndCommitDirty().commit()
+  def onSecondTag(n: String = "v2.0.0") = onTagAndSecondCommit().tag(n)
 
   final case class State() {
     val dir = doto(Files.createTempDirectory(s"dynver-test-").toFile)(_.deleteOnExit())
@@ -26,7 +31,11 @@ object RepoStates {
     var sha: String = "undefined"
 
     def init()         = andThis(git = Git.init().setDirectory(dir).call())
-    def dirty()        = andThis(Files.write(dir.toPath.resolve("f.txt"), Seq("1").asJava, CREATE, APPEND))
+    def dirty()        = {
+      // We randomize the content added otherwise we will get the same git hash for two separate commits
+      // because our commits are made at almost the same time
+      andThis(Files.write(dir.toPath.resolve("f.txt"), Seq(scala.util.Random.nextString(10)).asJava, CREATE, APPEND))
+    }
     def tag(n: String) = andThis(git.tag().setName(n).call())
 
     def commit() = andThis {
@@ -35,13 +44,39 @@ object RepoStates {
       sha = git.commit().setMessage("1").call().abbreviate(8).name()
     }
 
+    def branch(branchName: String) = andThis {
+      git.branchCreate().setName(branchName).call()
+      git.checkout().setName(branchName).call()
+    }
+
+    def checkout(branchName: String) = andThis {
+      git.checkout().setName(branchName).call()
+      sha = getCurrentHeadSHA
+    }
+
+    def merge(branchName: String) = andThis {
+      git.merge()
+        .include(git.getRepository.findRef(branchName))
+        .setCommit(true)
+        .setFastForward(FastForwardMode.NO_FF)
+        .setStrategy(MergeStrategy.OURS)
+        .call()
+      sha = getCurrentHeadSHA
+    }
+
     def version()         = dynver.version(date).replaceAllLiterally(sha, "1234abcd")
     def sonatypeVersion() = dynver.sonatypeVersion(date).replaceAllLiterally(sha, "1234abcd")
+    def previousVersion() = dynver.previousVersion
     def isSnapshot()      = dynver.isSnapshot()
     def isVersionStable() = dynver.isVersionStable()
 
     private def doalso[A, U](x: A)(xs: U*)  = x
     private def doto[A, U](x: A)(f: A => U) = doalso(x)(f(x))
     private def andThis[U](x: U)            = this
+
+    private def getCurrentHeadSHA = {
+      git.getRepository.findRef("HEAD").getObjectId.abbreviate(8).name()
+    }
   }
+
 }


### PR DESCRIPTION
This command always return the last tagged version before the current HEAD.
Most of the work was done by @MaxwellBo. I just fixed some issues found in usage and cleaned it up slightly. 

- Update SBT cross build version to 1.0.4 and update configs according to SBT crossbuilding guide

# NOTE
When I run `^ mimaReportBinaryIssues` it seems to only run the task for the current SBT version. Manually switching SBT cross build version using `^^ 1.0.4` then `mimaReportBinaryIssues` works fine. Maybe you can spot what I'm doing wrong but this is what I've done for other SBT plugins and it seems to work fine there