### PR TITLE
Make dynver work with source dependencies

### DIFF
--- a/src/main/scala/sbtdynver/DynVerPlugin.scala
+++ b/src/main/scala/sbtdynver/DynVerPlugin.scala
@@ -10,6 +10,7 @@ object DynVerPlugin extends AutoPlugin {
 
   object autoImport {
     val dynver                  = taskKey[String]("The version of your project, from git")
+    val dynverInstance          = settingKey[DynVer]("The dynver instance for this build.")
     val dynverCurrentDate       = settingKey[Date]("The current date, for dynver purposes")
     val dynverGitDescribeOutput = settingKey[Option[GitDescribeOutput]]("The output from git describe")
     val dynverCheckVersion      = taskKey[Boolean]("Checks if version and dynver match")
@@ -26,9 +27,10 @@ object DynVerPlugin extends AutoPlugin {
     isVersionStable := dynverGitDescribeOutput.value.isVersionStable,
 
     dynverCurrentDate       := new Date,
-    dynverGitDescribeOutput := DynVer.getGitDescribeOutput(dynverCurrentDate.value),
+    dynverInstance          := DynVer(Some((Keys.baseDirectory in ThisBuild).value)),
+    dynverGitDescribeOutput := dynverInstance.value.getGitDescribeOutput(dynverCurrentDate.value),
 
-    dynver                  := DynVer.version(new Date),
+    dynver                  := dynverInstance.value.version(new Date),
     dynverCheckVersion      := (dynver.value == version.value),
     dynverAssertVersion     := {
       val v = version.value

--- a/src/sbt-test/dynver/multi-build/bar/project/plugins.sbt
+++ b/src/sbt-test/dynver/multi-build/bar/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.dwijnand" % "sbt-dynver" % x)
+  case _       => sys.error("""|The system property 'plugin.version' is not defined.
+                               |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/src/sbt-test/dynver/multi-build/build.sbt
+++ b/src/sbt-test/dynver/multi-build/build.sbt
@@ -1,0 +1,45 @@
+dependsOn(RootProject(file("bar")))
+
+def check(a: String, e: String) = assert(a == e, s"Version mismatch: Expected $e, Incoming $a")
+
+TaskKey[Unit]("checkOnTagFoo") := check(version.value, "1.0.0")
+TaskKey[Unit]("checkOnTagBar") := check((version in RootProject(file("bar"))).value, "2.0.0")
+
+import sbt.complete.DefaultParsers._
+
+def exec(cmd: String, dir: File, streams: TaskStreams): String = {
+  import scala.sys.process._
+  implicit def log2log(log: Logger): ProcessLogger = sbtLoggerToScalaSysProcessLogger(log)
+  Process(cmd, Some(dir)) !! streams.log
+}
+
+val dirParser = Def setting fileParser(baseDirectory.value)
+val dirAndTagParser = Def setting (dirParser.value ~ (Space ~> StringBasic))
+
+InputKey[Unit]("gitInitSetup") := {
+  val dir = dirParser.value.parsed
+  exec("git init", dir, streams.value)
+  exec("git config user.email dynver@mailinator.com", dir, streams.value)
+  exec("git config user.name dynver", dir, streams.value)
+  IO.writeLines(dir / ".gitignore", Seq("target/"))
+}
+
+InputKey[Unit]("gitAdd")    := exec("git add .", dirParser.value.parsed, streams.value)
+InputKey[Unit]("gitCommit") := exec("git commit -am1", dirParser.value.parsed, streams.value)
+InputKey[Unit]("gitTag")    := {
+  val (dir, tag) = dirAndTagParser.value.parsed
+  exec(s"git tag -a v$tag -m '$tag'", dir, streams.value)
+}
+
+InputKey[Unit]("dirty") := {
+  import java.nio.file._, StandardOpenOption._
+  import scala.collection.JavaConverters._
+  Files.write(dirParser.value.parsed.toPath resolve "f.txt", Seq("1").asJava, CREATE, APPEND)
+}
+
+def sbtLoggerToScalaSysProcessLogger(log: Logger): scala.sys.process.ProcessLogger =
+  new scala.sys.process.ProcessLogger {
+    def buffer[T](f: => T): T   = f
+    def err(s: => String): Unit = log info s
+    def out(s: => String): Unit = log error s
+  }

--- a/src/sbt-test/dynver/multi-build/project/plugins.sbt
+++ b/src/sbt-test/dynver/multi-build/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.dwijnand" % "sbt-dynver" % x)
+  case _       => sys.error("""|The system property 'plugin.version' is not defined.
+                               |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/src/sbt-test/dynver/multi-build/test
+++ b/src/sbt-test/dynver/multi-build/test
@@ -1,0 +1,17 @@
+> gitInitSetup .
+> dirty .
+> gitAdd .
+> gitCommit .
+> gitTag . 1.0.0
+
+> reload
+> checkOnTagFoo
+
+> gitInitSetup bar
+> dirty bar
+> gitAdd bar
+> gitCommit bar
+> gitTag bar 2.0.0
+
+> reload
+> checkOnTagBar


### PR DESCRIPTION
When using source dependencies with git submodules, one wants the version created by sbt-dynver to be derived from the git submodule instead of the git metadata in the root repository.

This patch makes this work by introducing a `dynverInstance` that is created based on the value of `baseDirectory`.