### PR TITLE
Change the meaning of ThisBuild for source deps

### DIFF
--- a/src/main/scala/sbtdynver/DynVerPlugin.scala
+++ b/src/main/scala/sbtdynver/DynVerPlugin.scala
@@ -27,7 +27,10 @@ object DynVerPlugin extends AutoPlugin {
     isVersionStable := dynverGitDescribeOutput.value.isVersionStable,
 
     dynverCurrentDate       := new Date,
-    dynverInstance          := DynVer(Some((Keys.baseDirectory in ThisBuild).value)),
+    dynverInstance          := Def.settingDyn {
+      val ref = thisProjectRef.value
+      Def.setting(DynVer(Some((baseDirectory in ref in ThisBuild).value)))
+    },
     dynverGitDescribeOutput := dynverInstance.value.getGitDescribeOutput(dynverCurrentDate.value),
 
     dynver                  := dynverInstance.value.version(new Date),


### PR DESCRIPTION
It was an oversight on my side that I did not realize that `ThisBuild` would not resolve correctly in case it's used in a source dependency. I explained this is the source dependencies ticket in sbt/sbt.