### PR TITLE
WIP: Add support for versioning multiple subprojects

### DIFF
--- a/src/sbt-test/dynver/custom-version-string-0/build.sbt
+++ b/src/sbt-test/dynver/custom-version-string-0/build.sbt
@@ -1,7 +1,7 @@
 import scala.sys.process.stringToProcess
 
-version in ThisBuild ~= (_.replace('+', '-'))
- dynver in ThisBuild ~= (_.replace('+', '-'))
+version ~= (_.replace('+', '-'))
+ dynver ~= (_.replace('+', '-'))
 
 def tstamp = Def.setting(sbtdynver.DynVer timestamp dynverCurrentDate.value)
 def headSha = {

--- a/src/sbt-test/dynver/custom-version-string/build.sbt
+++ b/src/sbt-test/dynver/custom-version-string/build.sbt
@@ -5,13 +5,11 @@ def versionFmt(out: sbtdynver.GitDescribeOutput): String =
 
 def fallbackVersion(d: java.util.Date): String = s"HEAD-${sbtdynver.DynVer timestamp d}"
 
-inThisBuild(List(
-  version := dynverGitDescribeOutput.value.mkVersion(versionFmt, fallbackVersion(dynverCurrentDate.value)),
-   dynver := {
-     val d = new java.util.Date
-     sbtdynver.DynVer.getGitDescribeOutput(d).mkVersion(versionFmt, fallbackVersion(d))
-   }
-))
+version := dynverGitDescribeOutput.value.mkVersion(versionFmt, fallbackVersion(dynverCurrentDate.value))
+ dynver := {
+   val d = new java.util.Date
+   sbtdynver.DynVer.getGitDescribeOutput(d).mkVersion(versionFmt, fallbackVersion(d))
+ }
 
 def tstamp = Def.setting(sbtdynver.DynVer timestamp dynverCurrentDate.value)
 def headSha = {

--- a/src/sbt-test/dynver/multi-project/bar/build.sbt
+++ b/src/sbt-test/dynver/multi-project/bar/build.sbt
@@ -1,0 +1,1 @@
+dynverTagPrefix := "bar-"

--- a/src/sbt-test/dynver/multi-project/build.sbt
+++ b/src/sbt-test/dynver/multi-project/build.sbt
@@ -1,0 +1,55 @@
+import scala.sys.process.stringToProcess
+
+lazy val foo = project in file("foo")
+lazy val bar = project in file("bar")
+
+def tstamp = Def.setting(sbtdynver.DynVer timestamp dynverCurrentDate.value)
+def headSha = {
+  implicit def log2log(log: Logger): scala.sys.process.ProcessLogger = sbtLoggerToScalaSysProcessLogger(log)
+  Def.task("git rev-parse --short=8 HEAD".!!(streams.value.log).trim)
+}
+
+def check(a: String, e: String) = assert(a == e, s"Version mismatch: Expected $e, Incoming $a")
+
+TaskKey[Unit]("checkOnTagFoo") := check((version in foo).value, "1.0.0")
+TaskKey[Unit]("checkOnTagBar") := check((version in bar).value, "2.0.0")
+TaskKey[Unit]("checkOnTagBarDirty")          := check((version in bar).value, s"2.0.0+${tstamp.value}")
+TaskKey[Unit]("checkOnTagBarAndCommit")      := check((version in bar).value, s"2.0.0+1-${headSha.value}")
+TaskKey[Unit]("checkOnTagBarAndCommitDirty") := check((version in bar).value, s"2.0.0+1-${headSha.value}+${tstamp.value}")
+
+import sbt.complete.DefaultParsers._
+
+def exec(cmd: String, streams: TaskStreams): String = {
+  import scala.sys.process._
+  implicit def log2log(log: Logger): ProcessLogger = sbtLoggerToScalaSysProcessLogger(log)
+  cmd !! streams.log
+}
+
+val dirParser = Def setting fileParser(baseDirectory.value)
+val tagParser = Def setting (Space ~> StringBasic)
+
+InputKey[Unit]("gitInitSetup") := {
+  exec("git init .", streams.value)
+  exec("git config user.email dynver@mailinator.com", streams.value)
+  exec("git config user.name dynver", streams.value)
+  IO.writeLines(baseDirectory.value / ".gitignore", Seq("target/"))
+}
+InputKey[Unit]("gitAdd")    := exec("git add .", streams.value)
+InputKey[Unit]("gitCommit") := exec("git commit -am1", streams.value)
+InputKey[Unit]("gitTag")    := {
+  val tag = tagParser.value.parsed
+  exec(s"git tag -a $tag -m '$tag'", streams.value)
+}
+
+InputKey[Unit]("dirty") := {
+  import java.nio.file._, StandardOpenOption._
+  import scala.collection.JavaConverters._
+  Files.write(dirParser.value.parsed.toPath resolve "f.txt", Seq("1").asJava, CREATE, APPEND)
+}
+
+def sbtLoggerToScalaSysProcessLogger(log: Logger): scala.sys.process.ProcessLogger =
+  new scala.sys.process.ProcessLogger {
+    def buffer[T](f: => T): T   = f
+    def err(s: => String): Unit = log info s
+    def out(s: => String): Unit = log error s
+  }

--- a/src/sbt-test/dynver/multi-project/foo/build.sbt
+++ b/src/sbt-test/dynver/multi-project/foo/build.sbt
@@ -1,0 +1,1 @@
+dynverTagPrefix := "foo-"

--- a/src/sbt-test/dynver/multi-project/project/plugins.sbt
+++ b/src/sbt-test/dynver/multi-project/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.dwijnand" % "sbt-dynver" % x)
+  case _       => sys.error("""|The system property 'plugin.version' is not defined.
+                               |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/src/sbt-test/dynver/multi-project/test
+++ b/src/sbt-test/dynver/multi-project/test
@@ -1,0 +1,28 @@
+> gitInitSetup
+> dirty foo
+> gitAdd
+> gitCommit
+> gitTag foo-v1.0.0
+
+> reload
+> checkOnTagFoo
+
+> dirty bar
+> gitAdd
+> gitCommit
+> gitTag bar-v2.0.0
+
+> reload
+> checkOnTagBar
+
+> dirty bar
+> reload
+> checkOnTagBarDirty
+
+> gitCommit
+> reload
+> checkOnTagBarAndCommit
+
+> dirty bar
+> reload
+> checkOnTagBarAndCommitDirty

--- a/src/test/scala/sbtdynver/RepoStates.scala
+++ b/src/test/scala/sbtdynver/RepoStates.scala
@@ -20,7 +20,7 @@ object RepoStates {
   final case class State() {
     val dir = doto(Files.createTempDirectory(s"dynver-test-").toFile)(_.deleteOnExit())
     val date = new GregorianCalendar(2016, 8, 17).getTime
-    val dynver = DynVer(Some(dir))
+    val dynver = DynVer(Some(dir),"")
 
     var git: Git = _
     var sha: String = "undefined"


### PR DESCRIPTION
Do to so the settings are moved from the build to each project via using `projectSettings` instead of `buildSettings` and adding a new per project setting `dynverTagPrefix` to configure the project version tag prefix.

If these changes look acceptable, than I can update the PR to modify the docs and default the prefix to the project name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dwijnand/sbt-dynver/62)
<!-- Reviewable:end -->
