### PR TITLE
Append +0 to first dirty version after tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Other than that, as `sbt-dynver` is an AutoPlugin that is all that is required.
 | Case                                                                 | version                        | isSnapshot | isVersionStable |
 | -------------------------------------------------------------------- | ------------------------------ | ---------- | --------------- |
 | when on tag v1.0.0, w/o local changes                                | 1.0.0                          | false      | true            |
-| when on tag v1.0.0 with local changes                                | 1.0.0+20140707-1030            | true       | false           |
+| when on tag v1.0.0 with local changes                                | 1.0.0+0-1234abcd+20140707-1030 | true       | false           |
 | when on tag v1.0.0 +3 commits, on commit 1234abcd, w/o local changes | 1.0.0+3-1234abcd               | true       | true            |
 | when on tag v1.0.0 +3 commits, on commit 1234abcd with local changes | 1.0.0+3-1234abcd+20140707-1030 | true       | false           |
 | when there are no tags, on commit 1234abcd, w/o local changes        | 1234abcd                       | true       | true            |

--- a/src/main/scala/sbtdynver/DynVerPlugin.scala
+++ b/src/main/scala/sbtdynver/DynVerPlugin.scala
@@ -70,7 +70,7 @@ object GitDirtySuffix extends (String => GitDirtySuffix) {
 
 final case class GitDescribeOutput(ref: GitRef, commitSuffix: GitCommitSuffix, dirtySuffix: GitDirtySuffix) {
   def version: String            = {
-    if(isDirtyAfterTag) s"${ref.dropV.value}+0-${dirtySuffix.dropPlus.value}"
+    if(isDirtyAfterTag) s"${ref.dropV.value}+${commitSuffix.distance}-${commitSuffix.sha}-${dirtySuffix.dropPlus.value}"
     else ref.dropV.value + commitSuffix.mkString("+", "-", "") + dirtySuffix.value
   }
 
@@ -127,7 +127,7 @@ sealed case class DynVer(wd: Option[File]) {
   def hasNoTags(): Boolean                = getGitDescribeOutput(new Date).hasNoTags
 
   def getGitDescribeOutput(d: Date) = {
-    val process = scala.sys.process.Process(s"""git describe --tags --abbrev=8 --match v[0-9]* --always --dirty=+${timestamp(d)}""", wd)
+    val process = scala.sys.process.Process(s"""git describe --long --tags --abbrev=8 --match v[0-9]* --always --dirty=+${timestamp(d)}""", wd)
     Try(process !! impl.NoProcessLogger).toOption
       .map(_.replaceAll("-([0-9]+)-g([0-9a-f]{8})", "+$1-$2"))
       .map(GitDescribeOutput.parse)

--- a/src/main/scala/sbtdynver/DynVerPlugin.scala
+++ b/src/main/scala/sbtdynver/DynVerPlugin.scala
@@ -69,7 +69,12 @@ object GitDirtySuffix extends (String => GitDirtySuffix) {
 }
 
 final case class GitDescribeOutput(ref: GitRef, commitSuffix: GitCommitSuffix, dirtySuffix: GitDirtySuffix) {
-  def version: String            = ref.dropV.value + commitSuffix.mkString("+", "-", "") + dirtySuffix.value
+  def version: String            = {
+    if(isDirtyAfterTag) s"${ref.dropV.value}+0-${dirtySuffix.dropPlus.value}"
+    else ref.dropV.value + commitSuffix.mkString("+", "-", "") + dirtySuffix.value
+  }
+
+  def isDirtyAfterTag            = commitSuffix.distance == 0 && ref.isTag && isDirty()
   def isSnapshot(): Boolean      = isDirty() || hasNoTags() || commitSuffix.distance > 0
   def isVersionStable(): Boolean = !isDirty()
 

--- a/src/main/scala/sbtdynver/DynVerPlugin.scala
+++ b/src/main/scala/sbtdynver/DynVerPlugin.scala
@@ -70,7 +70,7 @@ object GitDirtySuffix extends (String => GitDirtySuffix) {
 
 final case class GitDescribeOutput(ref: GitRef, commitSuffix: GitCommitSuffix, dirtySuffix: GitDirtySuffix) {
   def version: String            = {
-    if(isDirtyAfterTag) s"${ref.dropV.value}+${commitSuffix.distance}-${commitSuffix.sha}-${dirtySuffix.dropPlus.value}"
+    if(isDirtyAfterTag) s"${ref.dropV.value}+${commitSuffix.distance}-${commitSuffix.sha}+${dirtySuffix.dropPlus.value}"
     else ref.dropV.value + commitSuffix.mkString("+", "-", "") + dirtySuffix.value
   }
 

--- a/src/sbt-test/dynver/custom-version-string-0/build.sbt
+++ b/src/sbt-test/dynver/custom-version-string-0/build.sbt
@@ -16,7 +16,7 @@ TaskKey[Unit]("checkNoCommits")           := check(version.value, s"HEAD-${tstam
 TaskKey[Unit]("checkOnCommit")            := check(version.value, s"${headSha.value}")
 TaskKey[Unit]("checkOnCommitDirty")       := check(version.value, s"${headSha.value}-${tstamp.value}")
 TaskKey[Unit]("checkOnTag")               := check(version.value, s"1.0.0")
-TaskKey[Unit]("checkOnTagDirty")          := check(version.value, s"1.0.0-${tstamp.value}")
+TaskKey[Unit]("checkOnTagDirty")          := check(version.value, s"1.0.0-0-${tstamp.value}")
 TaskKey[Unit]("checkOnTagAndCommit")      := check(version.value, s"1.0.0-1-${headSha.value}")
 TaskKey[Unit]("checkOnTagAndCommitDirty") := check(version.value, s"1.0.0-1-${headSha.value}-${tstamp.value}")
 

--- a/src/sbt-test/dynver/custom-version-string-0/build.sbt
+++ b/src/sbt-test/dynver/custom-version-string-0/build.sbt
@@ -16,7 +16,7 @@ TaskKey[Unit]("checkNoCommits")           := check(version.value, s"HEAD-${tstam
 TaskKey[Unit]("checkOnCommit")            := check(version.value, s"${headSha.value}")
 TaskKey[Unit]("checkOnCommitDirty")       := check(version.value, s"${headSha.value}-${tstamp.value}")
 TaskKey[Unit]("checkOnTag")               := check(version.value, s"1.0.0")
-TaskKey[Unit]("checkOnTagDirty")          := check(version.value, s"1.0.0-0-${tstamp.value}")
+TaskKey[Unit]("checkOnTagDirty")          := check(version.value, s"1.0.0-0-${headSha.value}-${tstamp.value}")
 TaskKey[Unit]("checkOnTagAndCommit")      := check(version.value, s"1.0.0-1-${headSha.value}")
 TaskKey[Unit]("checkOnTagAndCommitDirty") := check(version.value, s"1.0.0-1-${headSha.value}-${tstamp.value}")
 

--- a/src/sbt-test/dynver/versions/build.sbt
+++ b/src/sbt-test/dynver/versions/build.sbt
@@ -13,7 +13,7 @@ TaskKey[Unit]("checkNoCommits")           := check(version.value, s"HEAD+${tstam
 TaskKey[Unit]("checkOnCommit")            := check(version.value, s"${headSha.value}")
 TaskKey[Unit]("checkOnCommitDirty")       := check(version.value, s"${headSha.value}+${tstamp.value}")
 TaskKey[Unit]("checkOnTag")               := check(version.value, s"1.0.0")
-TaskKey[Unit]("checkOnTagDirty")          := check(version.value, s"1.0.0+0-${tstamp.value}")
+TaskKey[Unit]("checkOnTagDirty")          := check(version.value, s"1.0.0+0-${headSha.value}+${tstamp.value}")
 TaskKey[Unit]("checkOnTagAndCommit")      := check(version.value, s"1.0.0+1-${headSha.value}")
 TaskKey[Unit]("checkOnTagAndCommitDirty") := check(version.value, s"1.0.0+1-${headSha.value}+${tstamp.value}")
 

--- a/src/sbt-test/dynver/versions/build.sbt
+++ b/src/sbt-test/dynver/versions/build.sbt
@@ -13,7 +13,7 @@ TaskKey[Unit]("checkNoCommits")           := check(version.value, s"HEAD+${tstam
 TaskKey[Unit]("checkOnCommit")            := check(version.value, s"${headSha.value}")
 TaskKey[Unit]("checkOnCommitDirty")       := check(version.value, s"${headSha.value}+${tstamp.value}")
 TaskKey[Unit]("checkOnTag")               := check(version.value, s"1.0.0")
-TaskKey[Unit]("checkOnTagDirty")          := check(version.value, s"1.0.0+${tstamp.value}")
+TaskKey[Unit]("checkOnTagDirty")          := check(version.value, s"1.0.0+0-${tstamp.value}")
 TaskKey[Unit]("checkOnTagAndCommit")      := check(version.value, s"1.0.0+1-${headSha.value}")
 TaskKey[Unit]("checkOnTagAndCommitDirty") := check(version.value, s"1.0.0+1-${headSha.value}+${tstamp.value}")
 

--- a/src/test/scala/sbtdynver/DynVerSpec.scala
+++ b/src/test/scala/sbtdynver/DynVerSpec.scala
@@ -10,7 +10,7 @@ object VersionSpec extends Properties("VersionSpec") {
   property("on commit, w/o local changes")                  = onCommit().version()            ?= "1234abcd"
   property("on commit with local changes")                  = onCommitDirty().version()       ?= "1234abcd+20160917-0000"
   property("on tag v1.0.0, w/o local changes")              = onTag().version()               ?= "1.0.0"
-  property("on tag v1.0.0 with local changes")              = onTagDirty().version()          ?= "1.0.0+0-1234abcd-20160917-0000"
+  property("on tag v1.0.0 with local changes")              = onTagDirty().version()          ?= "1.0.0+0-1234abcd+20160917-0000"
   property("on tag v1.0.0 and 1 commit, w/o local changes") = onTagAndCommit().version()      ?= "1.0.0+1-1234abcd"
   property("on tag v1.0.0 and 1 commit with local changes") = onTagAndCommitDirty().version() ?= "1.0.0+1-1234abcd+20160917-0000"
 }

--- a/src/test/scala/sbtdynver/DynVerSpec.scala
+++ b/src/test/scala/sbtdynver/DynVerSpec.scala
@@ -10,7 +10,7 @@ object VersionSpec extends Properties("VersionSpec") {
   property("on commit, w/o local changes")                  = onCommit().version()            ?= "1234abcd"
   property("on commit with local changes")                  = onCommitDirty().version()       ?= "1234abcd+20160917-0000"
   property("on tag v1.0.0, w/o local changes")              = onTag().version()               ?= "1.0.0"
-  property("on tag v1.0.0 with local changes")              = onTagDirty().version()          ?= "1.0.0+20160917-0000"
+  property("on tag v1.0.0 with local changes")              = onTagDirty().version()          ?= "1.0.0+0-20160917-0000"
   property("on tag v1.0.0 and 1 commit, w/o local changes") = onTagAndCommit().version()      ?= "1.0.0+1-1234abcd"
   property("on tag v1.0.0 and 1 commit with local changes") = onTagAndCommitDirty().version() ?= "1.0.0+1-1234abcd+20160917-0000"
 }

--- a/src/test/scala/sbtdynver/DynVerSpec.scala
+++ b/src/test/scala/sbtdynver/DynVerSpec.scala
@@ -10,7 +10,7 @@ object VersionSpec extends Properties("VersionSpec") {
   property("on commit, w/o local changes")                  = onCommit().version()            ?= "1234abcd"
   property("on commit with local changes")                  = onCommitDirty().version()       ?= "1234abcd+20160917-0000"
   property("on tag v1.0.0, w/o local changes")              = onTag().version()               ?= "1.0.0"
-  property("on tag v1.0.0 with local changes")              = onTagDirty().version()          ?= "1.0.0+0-20160917-0000"
+  property("on tag v1.0.0 with local changes")              = onTagDirty().version()          ?= "1.0.0+0-1234abcd-20160917-0000"
   property("on tag v1.0.0 and 1 commit, w/o local changes") = onTagAndCommit().version()      ?= "1.0.0+1-1234abcd"
   property("on tag v1.0.0 and 1 commit with local changes") = onTagAndCommitDirty().version() ?= "1.0.0+1-1234abcd+20160917-0000"
 }


### PR DESCRIPTION
I wanted to fix #53 but you asked for #52 to be fixed first, so this adds a `+0` for dirty snapshots directly after a tag.

In the original bug ticket you say that you also want to add `+0000` but I'm confused by this. There was also the suggestion about adding the commit SHA, too.

Can you elaborate what should be there?

Fixes #52.