### PR TITLE
Document how to sanity check versions are derived from a tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,28 @@ Essentially this:
 2. defines the fallback version string, with `fallbackVersion`, and
 3. wires everything back together
 
+## Sanity checking the version
+
+As a sanity check, you can stop the build from loading by running a check during sbt's `onLoad`.
+For instance, to make sure that the version is derived from tags you can use:
+
+```scala
+Global / onLoad := (Global / onLoad).value.andThen { s =>
+  val v = version.value
+  if (dynverGitDescribeOutput.value.hasNoTags)
+    throw new MessageOnlyException(
+      s"Failed to derive version from git tags. Maybe run `git fetch --unshallow`? Version: $v"
+    )
+  s
+}
+```
+
+This will return an error message like the following:
+
+```
+[error] Failed to derive version from git tags. Maybe run `git fetch --unshallow`? Version: 3-d9489763
+```
+
 ## Dependencies
 
 * `git`, on the `PATH`

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.7
+sbt.version=1.2.8

--- a/src/main/scala/sbtdynver/DynVerPlugin.scala
+++ b/src/main/scala/sbtdynver/DynVerPlugin.scala
@@ -128,9 +128,8 @@ object GitDescribeOutput extends ((GitRef, GitCommitSuffix, GitDirtySuffix) => G
     def version(d: Date): String          = mkVersion(_.version, DynVer fallback d)
     def sonatypeVersion(d: Date): String  = mkVersion(_.sonatypeVersion, DynVer fallback d)
     def previousVersion: Option[String]   = _x.map(_.previousVersion)
-    def isSnapshot: Boolean               = _x.map(_.isSnapshot).getOrElse(true)
-    def isVersionStable: Boolean          = _x.map(_.isVersionStable).getOrElse(false)
-
+    def isSnapshot: Boolean               = _x.forall(_.isSnapshot)
+    def isVersionStable: Boolean          = _x.exists(_.isVersionStable)
 
     def isDirty: Boolean         = _x.fold(true)(_.isDirty())
     def hasNoTags: Boolean       = _x.fold(true)(_.hasNoTags())

--- a/src/main/scala/sbtdynver/DynVerPlugin.scala
+++ b/src/main/scala/sbtdynver/DynVerPlugin.scala
@@ -13,14 +13,14 @@ object DynVerPlugin extends AutoPlugin {
   override def trigger  = allRequirements
 
   object autoImport {
-    val dynver                  = taskKey[String]("The version of your project, from git")
-    val dynverInstance          = settingKey[DynVer]("The dynver instance for this build")
-    val dynverCurrentDate       = settingKey[Date]("The current date, for dynver purposes")
-    val dynverGitDescribeOutput = settingKey[Option[GitDescribeOutput]]("The output from git describe")
-    val dynverSonatypeSnapshots = settingKey[Boolean]("Whether to append -SNAPSHOT to snapshot versions")
+    val dynver                         = taskKey[String]("The version of your project, from git")
+    val dynverInstance                 = settingKey[DynVer]("The dynver instance for this build")
+    val dynverCurrentDate              = settingKey[Date]("The current date, for dynver purposes")
+    val dynverGitDescribeOutput        = settingKey[Option[GitDescribeOutput]]("The output from git describe")
+    val dynverSonatypeSnapshots        = settingKey[Boolean]("Whether to append -SNAPSHOT to snapshot versions")
     val dynverGitPreviousStableVersion = settingKey[Option[GitDescribeOutput]]("The last stable tag")
-    val dynverCheckVersion      = taskKey[Boolean]("Checks if version and dynver match")
-    val dynverAssertVersion     = taskKey[Unit]("Asserts if version and dynver match")
+    val dynverCheckVersion             = taskKey[Boolean]("Checks if version and dynver match")
+    val dynverAssertVersion            = taskKey[Unit]("Asserts if version and dynver match")
 
     // Would be nice if this were an 'upstream' key
     val isVersionStable         = settingKey[Boolean]("The version string identifies a specific point in version control, so artifacts built from this version can be safely cached")
@@ -32,17 +32,17 @@ object DynVerPlugin extends AutoPlugin {
     version := {
       val out = dynverGitDescribeOutput.value
       val date = dynverCurrentDate.value
-      if(dynverSonatypeSnapshots.value) out.sonatypeVersion(date)
+      if (dynverSonatypeSnapshots.value) out.sonatypeVersion(date)
       else out.version(date)
     },
     isSnapshot              := dynverGitDescribeOutput.value.isSnapshot,
     isVersionStable         := dynverGitDescribeOutput.value.isVersionStable,
     previousStableVersion   := dynverGitPreviousStableVersion.value.previousVersion,
 
-    dynverCurrentDate       := new Date,
-    dynverInstance          := DynVer(Some((Keys.baseDirectory in ThisBuild).value)),
-    dynverGitDescribeOutput := dynverInstance.value.getGitDescribeOutput(dynverCurrentDate.value),
-    dynverSonatypeSnapshots := false,
+    dynverCurrentDate              := new Date,
+    dynverInstance                 := DynVer(Some((baseDirectory in ThisBuild).value)),
+    dynverGitDescribeOutput        := dynverInstance.value.getGitDescribeOutput(dynverCurrentDate.value),
+    dynverSonatypeSnapshots        := false,
     dynverGitPreviousStableVersion := dynverInstance.value.getGitPreviousStableTag,
 
     dynver                  := dynverInstance.value.version(new Date),
@@ -83,15 +83,13 @@ object GitDirtySuffix extends (String => GitDirtySuffix) {
   }
 }
 final case class GitDescribeOutput(ref: GitRef, commitSuffix: GitCommitSuffix, dirtySuffix: GitDirtySuffix) {
-  def version: String            = {
+  def version: String = {
     if (isCleanAfterTag) ref.dropV.value + dirtySuffix.value // no commit info if clean after tag
     else if (commitSuffix.sha.nonEmpty) ref.dropV.value + "+" + commitSuffix.distance + "-" + commitSuffix.sha + dirtySuffix.value
     else commitSuffix.distance + "-" + ref.value + dirtySuffix.value
   }
 
-  def sonatypeVersion: String =
-    if(isSnapshot()) version + "-SNAPSHOT"
-    else version
+  def sonatypeVersion: String    = if (isSnapshot) version + "-SNAPSHOT" else version
 
   def isSnapshot(): Boolean      = hasNoTags() || !commitSuffix.isEmpty || isDirty()
   def previousVersion: String    = ref.dropV.value
@@ -166,9 +164,9 @@ sealed case class DynVer(wd: Option[File]) {
       .map(_.replaceAll("-([0-9]+)-g([0-9a-f]{8})", "+$1-$2"))
       .map(GitDescribeOutput.parse)
       .flatMap(output =>
-        if (output.hasNoTags) getDistanceToFirstCommit().map(dist => {
+        if (output.hasNoTags) getDistanceToFirstCommit().map(dist =>
           output.copy(commitSuffix = output.commitSuffix.copy(distance = dist))
-        })
+        )
         else Some(output)
       )
   }
@@ -193,6 +191,7 @@ sealed case class DynVer(wd: Option[File]) {
       .filter(_.trim.nonEmpty)
   }
 }
+
 object DynVer extends DynVer(None) with (Option[File] => DynVer)
 
 object `package`


### PR DESCRIPTION
Fixes #81

@2m Rather than introduce a setting and customise the definition of version (which is a SettingKey and therefore eagerly evaluated on load) I decided to invert it and just document how to build sanity checks on top of sbt-dynver.  We can always add a setting later if we find a reason.  WDYT?