### PR TITLE
Support dynverSonatypeSnapshots in the dynver task

### DIFF
--- a/src/main/scala/sbtdynver/DynVerPlugin.scala
+++ b/src/main/scala/sbtdynver/DynVerPlugin.scala
@@ -48,7 +48,11 @@ object DynVerPlugin extends AutoPlugin {
     dynverSonatypeSnapshots        := false,
     dynverGitPreviousStableVersion := dynverInstance.value.getGitPreviousStableTag,
 
-    dynver                  := dynverInstance.value.version(new Date),
+    dynver                  := {
+      val dynver = dynverInstance.value
+      if (dynverSonatypeSnapshots.value) dynver.sonatypeVersion(new Date)
+      else dynver.version(new Date)
+    },
     dynverCheckVersion      := (dynver.value == version.value),
     dynverAssertVersion     := {
       val v = version.value


### PR DESCRIPTION
This, in turn, makes dynverCheckVersion and dynverAssertVersion work.

Fixes #89