### PR TITLE
Derive previous version when tags are separated with another tag

### DIFF
--- a/src/test/scala/sbtdynver/DynVerSpec.scala
+++ b/src/test/scala/sbtdynver/DynVerSpec.scala
@@ -90,6 +90,11 @@ object PreviousVersionSpec extends Properties("PreviousVersionSpec") {
 
     state.previousVersion() ?= Some("1.1.0")
   }
+
+  property("contains unrelated tags in-between version tags") = {
+    val state = onTag().commit().tag("unrelated").commit().tag("v2.0.0")
+    state.previousVersion() ?= Some("1.0.0")
+  }
 }
 
 object IsSnapshotSpec extends Properties("IsSnapshotSpec") {


### PR DESCRIPTION
Currently all tags are considered in `git describe` for previous version derivation. However if `git describe` returns non-version tag, it is not parsed successfully and the previous version is None.

This PR makes the `git describe` command consider only tags starting with `v` for previous version derivation.