### PR TITLE
updated to support multi-project repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,12 @@ if the repo is cloned with `--no-tags`.
 
 Other than that, as `sbt-dynver` is an AutoPlugin that is all that is required.
 
+### Multi-Project Builds
+generally add `dynverTagPrefix in ThisProject := name.value`
+
 ## Detail
 
-`version in ThisBuild`, `isSnapshot in ThisBuild` and `isVersionStable in ThisBuild` will be automatically set to:
+`version`, `isSnapshot` and `isVersionStable` will be automatically set to:
 
 ```
 | tag    | dist | HEAD sha | dirty | version                        | isSnapshot | isVersionStable |
@@ -92,9 +95,9 @@ If you're not seeing what you expect, then either start with this:
 
     git tag -a v0.0.1 -m "Initial version tag for sbt-dynver"
 
-or change the value of `dynverVTagPrefix in ThisBuild` to remove the requirement for the v-prefix:
+or change the value of `dynverVTagPrefix in ThisProject` to remove the requirement for the v-prefix:
 
-    dynverVTagPrefix in ThisBuild := false
+    dynverVTagPrefix in ThisProject := false
 
 ## Tasks
 
@@ -106,7 +109,7 @@ or change the value of `dynverVTagPrefix in ThisBuild` to remove the requirement
 
 ## Publishing to Sonatype's snapshots repository (aka "Sonatype mode")
 
-If you're publishing to Sonatype sonashots then enable `dynverSonatypeSnapshots in ThisBuild := true` to append
+If you're publishing to Sonatype sonashots then enable `dynverSonatypeSnapshots in ThisProject := true` to append
 "-SNAPSHOT" to the version if `isSnapshot` is `true` (which it is unless building on a tag with no local
 changes).  This opt-in exists because the Sonatype's snapshots repository requires all versions to end with
 `-SNAPSHOT`.
@@ -116,18 +119,18 @@ changes).  This opt-in exists because the Sonatype's snapshots repository requir
 The default version string format includes `+` characters, which is not compatible with docker tags. This character can be overridden by setting:
 
 ```scala
-dynverSeparator in ThisBuild := "-"
+dynverSeparator := "-"
 ```
 
 ## Custom version string
 
 Sometimes you want to customise the version string. It might be for personal preference, or for compatibility with another tool or spec.
 
-For simple cases you can customise a versiou by simply post-processing the value of `version in ThisBuild` (and optionally `dynver in ThisBuild`), for example by replacing '+' with '-' (emulating the docker support mentioned above):
+For simple cases you can customise a versiou by simply post-processing the value of `version in ThisProject` (and optionally `dynver in ThisProject`), for example by replacing '+' with '-' (emulating the docker support mentioned above):
 
 ```scala
-version in ThisBuild ~= (_.replace('+', '-'))
- dynver in ThisBuild ~= (_.replace('+', '-'))
+version in ThisProject ~= (_.replace('+', '-'))
+ dynver in ThisProject ~= (_.replace('+', '-'))
 ```
 
 To completely customise the string format you can use `dynverGitDescribeOutput`, `dynverCurrentDate` and `sbtdynver.DynVer`, like so:
@@ -141,13 +144,13 @@ def versionFmt(out: sbtdynver.GitDescribeOutput): String = {
 
 def fallbackVersion(d: java.util.Date): String = s"HEAD-${sbtdynver.DynVer timestamp d}"
 
-inThisBuild(List(
+List(
   version := dynverGitDescribeOutput.value.mkVersion(versionFmt, fallbackVersion(dynverCurrentDate.value)),
    dynver := {
      val d = new java.util.Date
      sbtdynver.DynVer.getGitDescribeOutput(d).mkVersion(versionFmt, fallbackVersion(d))
    }
-))
+)
 ```
 
 Essentially this:

--- a/src/sbt-test/dynver/custom-version-string-0/build.sbt
+++ b/src/sbt-test/dynver/custom-version-string-0/build.sbt
@@ -1,7 +1,7 @@
 import scala.sys.process.stringToProcess
 
-version in ThisBuild ~= (_.replace('+', '-'))
- dynver in ThisBuild ~= (_.replace('+', '-'))
+version in ThisProject ~= (_.replace('+', '-'))
+ dynver in ThisProject ~= (_.replace('+', '-'))
 
 def tstamp = Def.setting(sbtdynver.DynVer timestamp dynverCurrentDate.value)
 def headSha = {

--- a/src/sbt-test/dynver/custom-version-string/build.sbt
+++ b/src/sbt-test/dynver/custom-version-string/build.sbt
@@ -8,13 +8,13 @@ def versionFmt(out: sbtdynver.GitDescribeOutput): String = {
 
 def fallbackVersion(d: java.util.Date): String = s"HEAD-${sbtdynver.DynVer timestamp d}"
 
-inThisBuild(List(
+List(
   version := dynverGitDescribeOutput.value.mkVersion(versionFmt, fallbackVersion(dynverCurrentDate.value)),
    dynver := {
      val d = new java.util.Date
      sbtdynver.DynVer.getGitDescribeOutput(d).mkVersion(versionFmt, fallbackVersion(d))
    }
-))
+)
 
 def tstamp = Def.setting(sbtdynver.DynVer timestamp dynverCurrentDate.value)
 def headSha = {

--- a/src/sbt-test/dynver/distance-separator/build.sbt
+++ b/src/sbt-test/dynver/distance-separator/build.sbt
@@ -1,6 +1,6 @@
 import scala.sys.process.stringToProcess
 
-dynverSeparator in ThisBuild := "-"
+dynverSeparator in ThisProject := "-"
 
 def tstamp = Def.setting(sbtdynver.DynVer timestamp dynverCurrentDate.value)
 def headSha = {

--- a/src/sbt-test/dynver/multi-project/bar/build.sbt
+++ b/src/sbt-test/dynver/multi-project/bar/build.sbt
@@ -1,0 +1,2 @@
+dynverTagPrefix in ThisProject := name.value
+dynverVTagPrefix in ThisProject := true

--- a/src/sbt-test/dynver/multi-project/build.sbt
+++ b/src/sbt-test/dynver/multi-project/build.sbt
@@ -1,0 +1,57 @@
+import sbtdynver.DynVer
+
+import scala.sys.process.stringToProcess
+
+lazy val foo = project in file("foo")
+lazy val bar = project in file("bar")
+
+def tstamp = Def.setting(DynVer timestamp dynverCurrentDate.value)
+def headSha = {
+  implicit def log2log(log: Logger): scala.sys.process.ProcessLogger = sbtLoggerToScalaSysProcessLogger(log)
+  Def.task("git rev-parse --short=8 HEAD".!!(streams.value.log).trim)
+}
+
+def check(a: String, e: String) = assert(a == e, s"Version mismatch: Expected $e, Incoming $a")
+
+TaskKey[Unit]("checkOnTagFoo") := check((version in foo).value, "1.0.0")
+TaskKey[Unit]("checkOnTagBar") := check((version in bar).value, "2.0.0")
+TaskKey[Unit]("checkOnTagBarDirty")          := check((version in bar).value, s"2.0.0+0-${headSha.value}+${tstamp.value}")
+TaskKey[Unit]("checkOnTagBarAndCommit")      := check((version in bar).value, s"2.0.0+1-${headSha.value}")
+TaskKey[Unit]("checkOnTagBarAndCommitDirty") := check((version in bar).value, s"2.0.0+1-${headSha.value}+${tstamp.value}")
+
+import sbt.complete.DefaultParsers._
+
+def exec(cmd: String, streams: TaskStreams): String = {
+  import scala.sys.process._
+  implicit def log2log(log: Logger): ProcessLogger = sbtLoggerToScalaSysProcessLogger(log)
+  cmd !! streams.log
+}
+
+val dirParser = Def setting fileParser(baseDirectory.value)
+val tagParser = Def setting (Space ~> StringBasic)
+
+InputKey[Unit]("gitInitSetup") := {
+  exec("git init .", streams.value)
+  exec("git config user.email dynver@mailinator.com", streams.value)
+  exec("git config user.name dynver", streams.value)
+  IO.writeLines(baseDirectory.value / ".gitignore", Seq("target/"))
+}
+InputKey[Unit]("gitAdd")    := exec("git add .", streams.value)
+InputKey[Unit]("gitCommit") := exec("git commit -am1", streams.value)
+InputKey[Unit]("gitTag")    := {
+  val tag = tagParser.value.parsed
+  exec(s"git tag -a $tag -m '$tag'", streams.value)
+}
+
+InputKey[Unit]("dirty") := {
+  import java.nio.file._, StandardOpenOption._
+  import scala.collection.JavaConverters._
+  Files.write(dirParser.value.parsed.toPath resolve "f.txt", Seq("1").asJava, CREATE, APPEND)
+}
+
+def sbtLoggerToScalaSysProcessLogger(log: Logger): scala.sys.process.ProcessLogger =
+  new scala.sys.process.ProcessLogger {
+    def buffer[T](f: => T): T   = f
+    def err(s: => String): Unit = log info s
+    def out(s: => String): Unit = log error s
+  }

--- a/src/sbt-test/dynver/multi-project/foo/build.sbt
+++ b/src/sbt-test/dynver/multi-project/foo/build.sbt
@@ -1,0 +1,2 @@
+dynverTagPrefix in ThisProject := name.value
+dynverVTagPrefix in ThisProject := true

--- a/src/sbt-test/dynver/multi-project/project/plugins.sbt
+++ b/src/sbt-test/dynver/multi-project/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.dwijnand" % "sbt-dynver" % x)
+  case _       => sys.error("""|The system property 'plugin.version' is not defined.
+                               |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/src/sbt-test/dynver/multi-project/test
+++ b/src/sbt-test/dynver/multi-project/test
@@ -1,0 +1,28 @@
+> gitInitSetup
+> dirty foo
+> gitAdd
+> gitCommit
+> gitTag foo-v1.0.0
+
+> reload
+> checkOnTagFoo
+
+> dirty bar
+> gitAdd
+> gitCommit
+> gitTag bar-v2.0.0
+
+> reload
+> checkOnTagBar
+
+> dirty bar
+> reload
+> checkOnTagBarDirty
+
+> gitCommit
+> reload
+> checkOnTagBarAndCommit
+
+> dirty bar
+> reload
+> checkOnTagBarAndCommitDirty

--- a/src/test/scala/sbtdynver/RepoStates.scala
+++ b/src/test/scala/sbtdynver/RepoStates.scala
@@ -10,9 +10,9 @@ import scala.collection.JavaConverters._
 import org.eclipse.jgit.api._
 import org.eclipse.jgit.merge.MergeStrategy
 
-object RepoStates extends RepoStates(vTagPrefix = true)
+object RepoStates extends RepoStates(vTagPrefix = true, tagPrefix = "")
 
-sealed class RepoStates(vTagPrefix: Boolean) {
+sealed class RepoStates(vTagPrefix: Boolean, tagPrefix: String) {
   def notAGitRepo()                     = new State()
   def noCommits()                       = notAGitRepo().init()
   def onCommit()                        = noCommits().commit().commit().commit()
@@ -29,7 +29,7 @@ sealed class RepoStates(vTagPrefix: Boolean) {
   final class State() {
     val dir = doto(Files.createTempDirectory(s"dynver-test-").toFile)(_.deleteOnExit())
     val date = new GregorianCalendar(2016, 8, 17).getTime
-    val dynver = DynVer(Some(dir), DynVer.separator, vTagPrefix)
+    val dynver = DynVer(Some(dir), DynVer.separator, vTagPrefix, tagPrefix)
 
     var git: Git = _
     var sha: String = "undefined"

--- a/src/test/scala/sbtdynver/TagPatternSpec.scala
+++ b/src/test/scala/sbtdynver/TagPatternSpec.scala
@@ -3,7 +3,7 @@ package sbtdynver
 import org.scalacheck._, Prop._
 
 object TagPatternVersionSpec extends Properties("TagPatternVersionSpec") {
-  val repoStates = new RepoStates(vTagPrefix = false)
+  val repoStates = new RepoStates(vTagPrefix = false, "")
   import repoStates._
 
   property("not a git repo")                               = notAGitRepo().version()          ?= "HEAD+20160917-0000"


### PR DESCRIPTION
closes #61 

add `dynverTagPrefix` that is empty by default but override with `name.value` of the project to support tags like <project>-v<version>

mostly inspired by #62