### PR TITLE
Workaround my JGit/symlink issue

### DIFF
--- a/src/test/scala/sbtdynver/JGitSystemReader.scala
+++ b/src/test/scala/sbtdynver/JGitSystemReader.scala
@@ -1,0 +1,80 @@
+package sbtdynver
+
+import java.io.{ File, IOException }
+import java.net.{ InetAddress, UnknownHostException }
+import java.nio.file.{ Files, InvalidPathException, Path, Paths }
+
+import org.eclipse.jgit.internal.JGitText
+import org.eclipse.jgit.lib.{ Config, Constants }
+import org.eclipse.jgit.storage.file.FileBasedConfig
+import org.eclipse.jgit.util.{ FS, StringUtils, SystemReader }
+import org.slf4j.LoggerFactory
+
+// Copy of org.eclipse.jgit.util.SystemReader.Default with:
+// * calls to Files.createDirectories guarded by if !Files.isDirectory
+//   necessary because my ~/.config is a symlink to a directory
+//   which Files.createDirectories isn't happy with
+object JGitSystemReader extends SystemReader {
+  private val LOG = LoggerFactory.getLogger(getClass)
+
+  lazy val init: Unit = SystemReader.setInstance(this)
+
+  override lazy val getHostname = {
+    try InetAddress.getLocalHost.getCanonicalHostName
+    catch { case _: UnknownHostException => "localhost" }
+  }.ensuring(_ != null)
+
+  override def getenv(variable: String): String = System.getenv(variable)
+  override def getProperty(key: String): String = System.getProperty(key)
+  override def getCurrentTime: Long             = System.currentTimeMillis
+  override def getTimezone(when: Long): Int     = getTimeZone.getOffset(when) / (60 * 1000)
+
+  override def openUserConfig(parent: Config, fs: FS) =
+    new FileBasedConfig(parent, new File(fs.userHome, ".gitconfig"), fs)
+
+  override def openSystemConfig(parent: Config, fs: FS): FileBasedConfig = {
+    if (StringUtils.isEmptyOrNull(getenv(Constants.GIT_CONFIG_NOSYSTEM_KEY))) {
+      val configFile = fs.getGitSystemConfig
+      if (configFile != null) return new FileBasedConfig(parent, configFile, fs)
+    }
+    new FileBasedConfig(parent, null, fs) {
+      override def load(): Unit = () // do not load
+      override def isOutdated   = false // regular class would bomb here
+    }
+  }
+
+  override def openJGitConfig(parent: Config, fs: FS): FileBasedConfig = {
+    val xdgPath = getXDGConfigHome(fs)
+    if (xdgPath != null) {
+      var configPath: Path = null
+      try {
+        configPath = xdgPath.resolve("jgit")
+        if (!Files.isDirectory(configPath))
+          Files.createDirectories(configPath)
+        configPath = configPath.resolve(Constants.CONFIG)
+        return new FileBasedConfig(parent, configPath.toFile, fs)
+      } catch {
+        case e: IOException =>
+          LOG.error(JGitText.get.createJGitConfigFailed, configPath: Any, e)
+      }
+    }
+    new FileBasedConfig(parent, new File(fs.userHome, ".jgitconfig"), fs)
+  }
+
+  private def getXDGConfigHome(fs: FS): Path = {
+    var configHomePath = getenv(Constants.XDG_CONFIG_HOME)
+    if (StringUtils.isEmptyOrNull(configHomePath))
+      configHomePath = new File(fs.userHome, ".config").getAbsolutePath
+    try {
+      val xdgHomePath = Paths.get(configHomePath)
+      if (!Files.isDirectory(xdgHomePath))
+        Files.createDirectories(xdgHomePath)
+      xdgHomePath
+    } catch {
+      case e @ (_: IOException | _: InvalidPathException) =>
+        LOG.error(JGitText.get.createXDGConfigHomeFailed, configHomePath: Any, e)
+        null
+    }
+  }
+}
+

--- a/src/test/scala/sbtdynver/RepoStates.scala
+++ b/src/test/scala/sbtdynver/RepoStates.scala
@@ -27,6 +27,8 @@ sealed class RepoStates(tagPrefix: String) {
   private def optPrefix(s: String) = if (s.startsWith(tagPrefix)) s else s"$tagPrefix$s"
 
   final class State() {
+    JGitSystemReader.init
+
     val dir = doto(Files.createTempDirectory(s"dynver-test-").toFile)(_.deleteOnExit())
     val date = new GregorianCalendar(2016, 8, 17).getTime
     val dynver = DynVer(Some(dir), DynVer.separator, tagPrefix)


### PR DESCRIPTION
I was hitting the following, locally, after recent JGit upgrades (I had
to keep reverting back to 5.5.1.201910021850-r where I wasn't hitting
the issue):

    java.nio.file.FileAlreadyExistsException: /Users/dnw/.config
    	at sun.nio.fs.UnixException.translateToIOException(UnixException.java:94) ~[?:?]
    	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111) ~[?:?]
    	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:116) ~[?:?]
    	at sun.nio.fs.UnixFileSystemProvider.createDirectory(UnixFileSystemProvider.java:389) ~[?:?]
    	at java.nio.file.Files.createDirectory(Files.java:689) ~[?:?]
    	at java.nio.file.Files.createAndCheckIsDirectory(Files.java:796) ~[?:?]
    	at java.nio.file.Files.createDirectories(Files.java:742) ~[?:?]
    	at org.eclipse.jgit.util.SystemReader$Default.getXDGConfigHome(SystemReader.java:120) ~[org.eclipse.jgit-5.7.0.202003110725-r.jar:5.7.0.202003110725-r]
    	at org.eclipse.jgit.util.SystemReader$Default.openJGitConfig(SystemReader.java:131) ~[org.eclipse.jgit-5.7.0.202003110725-r.jar:5.7.0.202003110725-r]
    	at org.eclipse.jgit.util.SystemReader.getJGitConfig(SystemReader.java:348) ~[org.eclipse.jgit-5.7.0.202003110725-r.jar:5.7.0.202003110725-r]
    	at org.eclipse.jgit.util.SystemReader.getSystemConfig(SystemReader.java:373) ~[org.eclipse.jgit-5.7.0.202003110725-r.jar:5.7.0.202003110725-r]
    	at org.eclipse.jgit.util.SystemReader.getUserConfig(SystemReader.java:321) ~[org.eclipse.jgit-5.7.0.202003110725-r.jar:5.7.0.202003110725-r]
    	at org.eclipse.jgit.internal.storage.file.FileRepository.<init>(FileRepository.java:162) ~[org.eclipse.jgit-5.7.0.202003110725-r.jar:5.7.0.202003110725-r]
    	at org.eclipse.jgit.lib.BaseRepositoryBuilder.build(BaseRepositoryBuilder.java:583) ~[org.eclipse.jgit-5.7.0.202003110725-r.jar:5.7.0.202003110725-r]
    	at org.eclipse.jgit.api.InitCommand.call(InitCommand.java:90) ~[org.eclipse.jgit-5.7.0.202003110725-r.jar:5.7.0.202003110725-r]
    	at sbtdynver.RepoStates$State.init(RepoStates.scala:39) ~[test-classes/:?]

The cause is my ~/.config is a symlink'd directory, for which the
default Files.createDirectories throws an exception.  Now (IIRC) there
was a fallback so it was "just" logging spam, but I grew tired of it.