### PR TITLE
Workaround my (new) JGit/FileStore issue

### DIFF
--- a/src/test/scala/sbtdynver/RepoStates.scala
+++ b/src/test/scala/sbtdynver/RepoStates.scala
@@ -26,9 +26,12 @@ sealed class RepoStates(tagPrefix: String) {
 
   private def optPrefix(s: String) = if (s.startsWith(tagPrefix)) s else s"$tagPrefix$s"
 
-  final class State() {
-    JGitSystemReader.init
+  locally {
+    JGitSystemReader.init // see JGitSystemReader's docs
+    noCommits() // & seed JGit's FS.FileStoreAttributes.attributeCache with my tmp directory's BsdFileStore
+  }
 
+  final class State() {
     val dir = doto(Files.createTempDirectory(s"dynver-test-").toFile)(_.deleteOnExit())
     val date = new GregorianCalendar(2016, 8, 17).getTime
     val dynver = DynVer(Some(dir), DynVer.separator, tagPrefix)


### PR DESCRIPTION
I was hitting this:

    [info] > Exception: java.util.concurrent.RejectedExecutionException: Task java.util.concurrent.CompletableFuture$AsyncSupply@35a283ef rejected from java.util.concurrent.ThreadPoolExecutor@630de0e4[Running, pool size = 5, active threads = 5, queued tasks = 0, completed tasks = 0]
    [info] java.util.concurrent.ThreadPoolExecutor$AbortPolicy.rejectedExecution(ThreadPoolExecutor.java:2055)
    [info] java.util.concurrent.ThreadPoolExecutor.reject(ThreadPoolExecutor.java:825)
    [info] java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1355)
    [info] java.util.concurrent.CompletableFuture.asyncSupplyStage(CompletableFuture.java:1714)
    [info] java.util.concurrent.CompletableFuture.supplyAsync(CompletableFuture.java:1931)
    [info] org.eclipse.jgit.util.FS$FileStoreAttributes.getFileStoreAttributes(FS.java:329)
    [info] org.eclipse.jgit.util.FS$FileStoreAttributes.get(FS.java:296)
    [info] org.eclipse.jgit.util.FS.getFileStoreAttributes(FS.java:767)
    [info] org.eclipse.jgit.internal.storage.file.FileSnapshot.<init>(FileSnapshot.java:224)
    [info] org.eclipse.jgit.internal.storage.file.FileSnapshot.<init>(FileSnapshot.java:205)
    [info] org.eclipse.jgit.internal.storage.file.FileSnapshot.save(FileSnapshot.java:102)
    [info] org.eclipse.jgit.internal.storage.file.FileRepository.<init>(FileRepository.java:209)
    [info] org.eclipse.jgit.lib.BaseRepositoryBuilder.build(BaseRepositoryBuilder.java:583)
    [info] org.eclipse.jgit.api.InitCommand.call(InitCommand.java:90)
    [info] sbtdynver.RepoStates$State.init(RepoStates.scala:39)

The cause seems to be that JGit's `FS` tries to `getFileStoreAttributes`
asynchronously with a thread pool of 5.  Because my tmp directory is
mounted it counts as a separate "FileStore", so all my test properties
were concurrently trying to seed the file store attributes into the
(global) cache, running out of threads.

So seed it early, once, to workaround the issue.