### PR TITLE
Use `moduleName` rather than `name` in mimaPreviousArtifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ comes from the branch you merged into (e.g. `master` in `git checkout master && 
 To use this feature with the Migration Manager [MiMa](https://github.com/lightbend/migration-manager) sbt plugin, add
 
 ```scala
-mimaPreviousArtifacts := previousStableVersion.value.map(organization.value %% name.value % _).toSet
+mimaPreviousArtifacts := previousStableVersion.value.map(organization.value %% moduleName.value % _).toSet
 ```
 
 ## Tag Requirements


### PR DESCRIPTION
which is better, according to https://github.com/lightbend/mima#setting-mimapreviousartifacts-when-name-contains-a-